### PR TITLE
Allow use of the `BENTOML_CONFIG_OPTIONS` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ The required configuration is:
 - `max_instances`: The maximum number of instances Cloud Run should scale up to under load. Check the [dcos](https://cloud.google.com/run/docs/configuring/max-instances) on how to configure it
 - `memory`: The RAM that should be available for each instance. If your model uses more than the specified RAM, it will be terminated. Check the [docs](https://cloud.google.com/run/docs/configuring/memory-limits)
 - `cpu`: The number of CPUs needed for each instance. Check the [docs](https://cloud.google.com/run/docs/configuring/cpu) for more info
+- `bentoml_config_options`: Used to set the `BENTOML_CONFIG_OPTIONS` environment variable. Check the [docs](https://docs.bentoml.org/en/latest/guides/configuration.html#overrding-configuration-with-environment-variables) for more info

--- a/google_cloud_run_deploy/templates/terraform_default.tf
+++ b/google_cloud_run_deploy/templates/terraform_default.tf
@@ -80,6 +80,12 @@ variable "cpu" {
   default     = 1
 }
 
+variable "bentoml_config_options" {
+  description = "Used to set the `BENTOML_CONFIG_OPTIONS` environment variable"
+  type        = string
+  default     = ""
+}
+
 ################################################################################
 # Resource definitions
 ################################################################################
@@ -117,6 +123,10 @@ resource "google_cloud_run_service" "run_service" {
         env {
           name  = "BENTOML_PORT"
           value = var.port
+        }
+        env {
+          name  = "BENTOML_CONFIG_OPTIONS"
+          value = var.bentoml_config_options
         }
         ports {
           container_port = var.port

--- a/google_cloud_run_deploy/values.py
+++ b/google_cloud_run_deploy/values.py
@@ -1,7 +1,7 @@
 from collections import UserDict
 
-DEPLOYMENT_PARAMS_WARNING = """# This file is maintained automatically by 
-# "bentoctl generate" and "bentoctl build" commands. 
+DEPLOYMENT_PARAMS_WARNING = """# This file is maintained automatically by
+# "bentoctl generate" and "bentoctl build" commands.
 # Manual edits may be lost the next time these commands are run.
 
 """
@@ -35,6 +35,8 @@ class DeploymentValues(UserDict):
     def generate_terraform_tfvars_file(self, file_path):
         params = []
         for param_name, param_value in self.items():
+            if param_name == "bentoml_config_options":
+                param_value = param_value.replace("\n", ",")
             params.append(f'{param_name} = "{param_value}"')
 
         with open(file_path, "w") as params_file:

--- a/operator_config.py
+++ b/operator_config.py
@@ -1,6 +1,3 @@
-from email.policy import default
-
-
 OPERATOR_SCHEMA = {
     "project_id": {
         "required": True,

--- a/operator_config.py
+++ b/operator_config.py
@@ -1,3 +1,6 @@
+from email.policy import default
+
+
 OPERATOR_SCHEMA = {
     "project_id": {
         "required": True,
@@ -43,6 +46,13 @@ OPERATOR_SCHEMA = {
         "coerce": int,
         "default": 1,
         "help_message": "CPU cores for each available instance. Note: container instances only get CPU during request processing and startup. Read more https://cloud.google.com/run/docs/configuring/cpu-allocation",
+    },
+    "bentoml_config_options": {
+        "required": True,
+        "type": "string",
+        "coerce": str,
+        "default": "",
+        "help_message": "Used to set the `BENTOML_CONFIG_OPTIONS` envirmonmental variable. Read more: https://docs.bentoml.org/en/latest/guides/configuration.html#overrding-configuration-with-environment-variables",
     },
 }
 


### PR DESCRIPTION
This will allow the user to override the default configuration for things like the number of `api_workers`