### PR TITLE
feat: support `env` coming from `bentoctl`

### DIFF
--- a/google_cloud_run_deploy/templates/terraform_default.tf
+++ b/google_cloud_run_deploy/templates/terraform_default.tf
@@ -97,6 +97,12 @@ variable "invokers" {
   default     = ["allUsers"]
 }
 
+variable "env" {
+  description = "Runtime environment variables"
+  type        = map(string)
+  default     = {}
+}
+
 ################################################################################
 # Resource definitions
 ################################################################################
@@ -138,6 +144,13 @@ resource "google_cloud_run_service" "run_service" {
         env {
           name  = "BENTOML_PORT"
           value = var.port
+        }
+        dynamic "env" {
+          for_each = var.env
+          content {
+            name  = each.key
+            value = each.value
+          }
         }
         ports {
           container_port = var.port

--- a/google_cloud_run_deploy/values.py
+++ b/google_cloud_run_deploy/values.py
@@ -1,8 +1,8 @@
 from collections import UserDict
 import json
 
-DEPLOYMENT_PARAMS_WARNING = """# This file is maintained automatically by 
-# "bentoctl generate" and "bentoctl build" commands. 
+DEPLOYMENT_PARAMS_WARNING = """# This file is maintained automatically by
+# "bentoctl generate" and "bentoctl build" commands.
 # Manual edits may be lost the next time these commands are run.
 
 """
@@ -36,7 +36,7 @@ class DeploymentValues(UserDict):
     def generate_terraform_tfvars_file(self, file_path):
         params = []
         for param_name, param_value in self.items():
-            if isinstance(param_value, list):
+            if isinstance(param_value, (dict, list)):
                 write_value = json.dumps(param_value)
             else:
                 write_value = f'"{param_value}"'


### PR DESCRIPTION
This should actually be very very simple as it is just an additional `dict` key coming through which can be dumped as JSON.